### PR TITLE
[tool] json_keys

### DIFF
--- a/tools/json_keys.py
+++ b/tools/json_keys.py
@@ -1,0 +1,11 @@
+# tool: json_keys
+# description: Lists the top-level keys of a JSON object
+# author: @zaid-brk
+# example: json_keys '{"a":1,"b":2}' → '["a", "b"]'
+
+import json
+
+
+def run(*args) -> str:
+    data = json.loads(args[0])
+    return json.dumps(list(data.keys()))

--- a/tools/json_keys.py
+++ b/tools/json_keys.py
@@ -8,4 +8,6 @@ import json
 
 def run(*args) -> str:
     data = json.loads(args[0])
+    if not isinstance(data, dict):
+        return "Error: input must be a JSON object"
     return json.dumps(list(data.keys()))


### PR DESCRIPTION
Implements #167 — lists top-level keys of a JSON object.

Tested locally:
```
python bitbox.py json_keys '{"a":1,"b":2}'
["a", "b"]
```