### PR TITLE
[tool] path_basename

### DIFF
--- a/tools/path_basename.py
+++ b/tools/path_basename.py
@@ -1,0 +1,13 @@
+# tool: path_basename
+# description: Returns the final component of a file path
+# author: @isaac-sun
+# example: path_basename "/home/user/docs/file.txt" → "file.txt"
+
+from pathlib import PurePath
+
+
+def run(*args) -> str:
+    if not args:
+        raise ValueError("path_basename requires a path argument")
+    path = str(args[0])
+    return PurePath(path).name


### PR DESCRIPTION
## Summary
Implements `path_basename` — returns the final component of a file path.

Closes #178

## Example
```bash
python bitbox.py path_basename "/home/user/docs/file.txt"
# file.txt
```

## Notes
- stdlib only (`pathlib.PurePath`)
- Header comments follow CONTRIBUTING.md
- Author: @isaac-sun

## Contribution policy check
- Repo badge: contributions welcome
- CONTRIBUTING.md: 3-step tool loop
- Issue unassigned, no competing open PR at start
- Recent external PRs merged same day