### PR TITLE
[tool] path_join

### DIFF
--- a/tools/path_join.py
+++ b/tools/path_join.py
@@ -1,0 +1,22 @@
+# tool: path_join
+# description: Joins multiple path segments into one normalized path
+# author: @isaac-sun
+# example: path_join "/home/user" "docs" "file.txt" → "/home/user/docs/file.txt"
+
+import os
+from pathlib import PurePosixPath, PureWindowsPath
+
+
+def run(*args) -> str:
+    if not args:
+        raise ValueError("path_join requires at least one path segment")
+    parts = [str(a) for a in args]
+    if os.name == "nt":
+        joined = PureWindowsPath(parts[0])
+        for part in parts[1:]:
+            joined = joined.joinpath(part)
+        return str(joined)
+    joined = PurePosixPath(parts[0])
+    for part in parts[1:]:
+        joined = joined.joinpath(part)
+    return str(joined)


### PR DESCRIPTION
## Summary
Implements `path_join` — joins multiple path segments into one normalized path.

Closes #175

## Example
```bash
python bitbox.py path_join "/home/user" "docs" "file.txt"
# /home/user/docs/file.txt
```

## Notes
- stdlib only
- POSIX join on non-Windows (matches issue example); native Windows paths on `nt`
- Author: @isaac-sun

## Contribution policy check
- Repo badge: contributions welcome
- CONTRIBUTING.md present; unassigned issue; first-come tool requests
- Recent community tool PRs actively merged