### PR TITLE
[tool] file_stem

### DIFF
--- a/tools/file_stem.py
+++ b/tools/file_stem.py
@@ -9,6 +9,6 @@ def run(*args) -> str:
     last_slash = txt.rfind('/') + 1
     last_dot = txt.rfind('.') if txt.rfind('.') != -1 else None
 
-    if last_slash == last_dot:
+    if txt[last_slash] == '.':
         return txt[last_slash:]
     return txt[last_slash:last_dot]

--- a/tools/file_stem.py
+++ b/tools/file_stem.py
@@ -1,0 +1,14 @@
+# tool: file_stem
+# description: Returns the filename without its extension
+# author: @tmshnko
+# example: file_stem "/home/user/photo.tar.gz" -> "photo.tar"
+
+
+def run(*args) -> str:
+    txt = str(args[0])
+    last_slash = txt.rfind('/') + 1
+    last_dot = txt.rfind('.') if txt.rfind('.') != -1 else None
+
+    if last_slash == last_dot:
+        return txt[last_slash:]
+    return txt[last_slash:last_dot]


### PR DESCRIPTION
Returns the filename without extension. 
It also covers next cases:
- the path is relative 
- the file has no extension
- file starts with dot like .env

## Checklist

- [*] File is in `tools/` directory
- [*] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [*] File has a `run()` function that returns a string
- [*] Uses stdlib only (no external dependencies)
- [*] Tested locally with `python bitbox.py <tool_name> <args>`

Closes #174 
