### PR TITLE
[tool] reading_time (#163)

### DIFF
--- a/tools/reading_time.py
+++ b/tools/reading_time.py
@@ -1,0 +1,19 @@
+# tool: reading_time
+# description: Estimates reading time in minutes (assuming 200 wpm)
+# author: @PurpleSwtr
+# example: reading_time "400 words of text here" -> "2"
+
+
+import sys
+
+
+def run(*args) -> str:
+    text = args[0] if args else sys.stdin.read()
+
+    word_count = len(text.strip().split())
+
+    if word_count == 0:
+        return "0"
+
+    minutes = (word_count + 100) // 200
+    return str(minutes)

--- a/tools/reading_time.py
+++ b/tools/reading_time.py
@@ -4,16 +4,10 @@
 # example: reading_time "400 words of text here" -> "2"
 
 
-import sys
-
-
 def run(*args) -> str:
-    text = args[0] if args else sys.stdin.read()
-
+    text = args[0]
     word_count = len(text.strip().split())
-
     if word_count == 0:
         return "0"
-
     minutes = (word_count + 100) // 200
     return str(minutes)


### PR DESCRIPTION
## Summary

Adds the reading_time tool requested in #163.

## Behavior

I implemented two ways to send text. (If this isn't suitable, I can easily fix it and remove this functionality.) 

But I thought it would be convenient to also be able to send a file path to the tool, rather than, for example, pasting 5,000+ lines of text into the terminal. 
It uses the standard Python method of redirecting input file using the "<" operator on the command line.

## Examples

I used rounding by adding half the divisor.

(90 words): (90 + 100) // 200 -> 190 // 200 = 0 (rounded down, since it's less than half).
(110 words): (110 + 100) // 200 -> 210 // 200 = 1 (rounded up, since it's over the threshold).
(290 words): (290 + 100) // 200 -> 390 // 200 = 1 (rounded down, closer to 1).
(310 words): (310 + 100) // 200 -> 410 // 200 = 2 (rounded up, closer to 2).

- `python bitbox.py reading_time "text, < 100 words"` -> `0`
- `python bitbox.py reading_time "text, = 100 words"` -> `1`
- `python bitbox.py reading_time "text, = 200 words"` -> `1`
- `python bitbox.py reading_time "text, = 400 words"` -> `2`

and also i tested this on some files, this is the second way to use:

- `python bitbox.py reading_time < "README.md"` -> `2` (397 words) p.s. file of this project
- `python bitbox.py reading_time < "1.md"` -> `5` (959 words)
- `python bitbox.py reading_time < "2.md"` -> `22` (4469 words)

## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a `run()` function that returns a string
- [x] Uses stdlib only (no external dependencies)
- [x] Tested locally with `python bitbox.py <tool_name> <args>`

Closes #163