### PR TITLE
feat(tools): add path_parent

### DIFF
--- a/tools/path_parent.py
+++ b/tools/path_parent.py
@@ -1,0 +1,13 @@
+# tool: path_parent
+# description: returns the parent directory of a path
+# author: @Solaris-star
+# example: path_parent "/tmp/foo/bar.txt" -> "/tmp/foo"
+
+from pathlib import PurePosixPath
+
+
+def run(*args) -> str:
+    if not args:
+        return "Error: expected a path argument"
+    return str(PurePosixPath(args[0]).parent)
+


### PR DESCRIPTION
## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a `run()` function that returns a string
- [x] Uses stdlib only (no external dependencies)
- [x] Tested locally with `python bitbox.py path_parent <args>`

Closes #176