### PR TITLE
feat(tools): add xml_escape

### DIFF
--- a/tools/xml_escape.py
+++ b/tools/xml_escape.py
@@ -1,0 +1,13 @@
+# tool: xml_escape
+# description: escapes XML special characters in a string
+# author: @Solaris-star
+# example: xml_escape "<tag>" -> "&lt;tag&gt;"
+
+import xml.sax.saxutils as saxutils
+
+
+def run(*args) -> str:
+    if not args:
+        return "Error: expected a string argument"
+    return saxutils.escape(args[0], entities={'"': "&quot;", "'": "&apos;"})
+


### PR DESCRIPTION
## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a `run()` function that returns a string
- [x] Uses stdlib only (no external dependencies)
- [x] Tested locally with `python bitbox.py xml_escape <args>`

Closes #170