### PR TITLE
[tool] index_of

### DIFF
--- a/tools/index_of.py
+++ b/tools/index_of.py
@@ -1,0 +1,9 @@
+# tool: index_of
+# description: Find the index of first occurrence of a substring
+# author: @AshSgDe29071999
+# example: index_of "hello" "ll" -> "2"
+
+def run(*args) -> str:
+    text = args[0]
+    sub = args[1]
+    return str(text.find(sub))


### PR DESCRIPTION
## Summary
Adds `index_of` following the existing tool template.

Example: `index_of "hello" "ll"` → `2` (returns `-1` when absent)

Fixes #314