### PR TITLE
[tool] is_palindrome_ignore_spaces

### DIFF
--- a/tests/test_is_palindrome_ignore_spaces.py
+++ b/tests/test_is_palindrome_ignore_spaces.py
@@ -1,0 +1,27 @@
+import pytest
+from tools.is_palindrome_ignore_spaces import run
+
+
+def test_is_palindrome_ignore_spaces_true():
+    assert run("nurses run") == "True"
+    assert run("racecar") == "True"
+    assert run("was it a car or a cat i saw") == "True"
+
+
+def test_is_palindrome_ignore_spaces_case_insensitive():
+    assert run("Nurses Run") == "True"
+
+
+def test_is_palindrome_ignore_spaces_false():
+    assert run("hello world") == "False"
+    assert run("nurses run!") == "False"
+
+
+def test_is_palindrome_ignore_spaces_single_char_and_empty():
+    assert run("a") == "True"
+    assert run("") == "True"
+    assert run("   ") == "True"
+
+
+def test_is_palindrome_ignore_spaces_no_args():
+    assert run() == "Error: expected a string argument"

--- a/tools/is_palindrome_ignore_spaces.py
+++ b/tools/is_palindrome_ignore_spaces.py
@@ -1,0 +1,13 @@
+# tool: is_palindrome_ignore_spaces
+# description: Checks if a string is a palindrome ignoring spaces
+# author: @Jesulac
+# example: is_palindrome_ignore_spaces "nurses run" -> "True"
+
+
+def run(*args) -> str:
+    if not args:
+        return "Error: expected a string argument"
+    # Only whitespace is ignored (punctuation is kept, unlike is_palindrome).
+    # Comparison is case-insensitive, matching the existing is_palindrome tool.
+    cleaned = "".join(args[0].split()).lower()
+    return str(cleaned == cleaned[::-1])


### PR DESCRIPTION
Closes #320.

Adds `tools/is_palindrome_ignore_spaces.py`: checks whether a string is a palindrome ignoring whitespace.

- `run(*args) -> str`, stdlib only, no external dependencies
- Required header comments (tool/description/author/example) included
- Only whitespace is ignored — punctuation is kept, which is what differentiates it from the existing `is_palindrome` (that one strips every non-alphanumeric character). Comparison is case-insensitive, consistent with `is_palindrome`
- Missing-argument case returns `Error: expected a string argument`, matching the convention in `compress_whitespace`

Example:
```
python bitbox.py is_palindrome_ignore_spaces "nurses run"   # True
python bitbox.py is_palindrome_ignore_spaces "hello world"  # False
```

Also adds `tests/test_is_palindrome_ignore_spaces.py`. Full suite run locally with `python -m pytest`: **13 passed, 0 failed** (8 pre-existing + 5 new). No existing files were modified.