### PR TITLE
[tool] degrees_to_radians

### DIFF
--- a/tools/degrees_to_radians.py
+++ b/tools/degrees_to_radians.py
@@ -1,0 +1,15 @@
+# tool: degrees_to_radians
+# description: Converts an angle from degrees to radians
+# author: @shaurya703
+# example: degrees_to_radians "180" -> "3.141592653589793"
+
+import math
+
+
+def run(*args) -> str:
+    try:
+        degrees = float(args[0])
+        return str(math.radians(degrees))
+    except (ValueError, IndexError):
+        bad = args[0] if args else ""
+        return f"Error: '{bad}' is not a valid number"


### PR DESCRIPTION
Fixes #373

Adds the `degrees_to_radians` tool: converts an angle from degrees to radians using `math.radians` (radians = degrees × π/180).

## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a single `run(*args) -> str` function
- [x] Stdlib only, no external dependencies
- [x] Tested locally: `python bitbox.py degrees_to_radians "180"` -> `3.141592653589793`; invalid input returns an error string
