### PR TITLE
[tool] radians_to_degrees

### DIFF
--- a/tools/radians_to_degrees.py
+++ b/tools/radians_to_degrees.py
@@ -1,0 +1,15 @@
+# tool: radians_to_degrees
+# description: Converts an angle from radians to degrees
+# author: @shaurya703
+# example: radians_to_degrees "3.14159" -> "179.9998"
+
+import math
+
+
+def run(*args) -> str:
+    try:
+        radians = float(args[0])
+        return str(round(math.degrees(radians), 4))
+    except (ValueError, IndexError):
+        bad = args[0] if args else ""
+        return f"Error: '{bad}' is not a valid number"


### PR DESCRIPTION
Fixes #374

Adds the `radians_to_degrees` tool: converts an angle from radians to degrees using `math.degrees` (degrees = radians × 180/π), rounded to 4 decimal places to match the requested example.

## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a single `run(*args) -> str` function
- [x] Stdlib only, no external dependencies
- [x] Tested locally: `python bitbox.py radians_to_degrees "3.14159"` -> `179.9998`; invalid input returns an error string
