### PR TITLE
[tool] octal_to_binary

### DIFF
--- a/tools/octal_to_binary.py
+++ b/tools/octal_to_binary.py
@@ -1,0 +1,16 @@
+# tool: octal_to_binary
+# description: Converts an octal string to its binary string representation
+# author: @Solaris-star
+# example: octal_to_binary "12" -> "1010"
+
+
+def run(*args) -> str:
+    if len(args) != 1:
+        return "Error: Please provide exactly one argument."
+
+    try:
+        value = int(args[0], 8)
+    except ValueError:
+        return "Error: Input must be a valid octal number."
+
+    return bin(value)[2:]


### PR DESCRIPTION
## Checklist

- [x] File is in `tools/` directory
- [x] File has header comments (`# tool`, `# description`, `# author`, `# example`)
- [x] File has a `run()` function that returns a string
- [x] Uses stdlib only (no external dependencies)
- [x] Tested locally with `python bitbox.py <tool_name> <args>`

## Testing

- `python3 bitbox.py octal_to_binary 12` → `1010`
- `python3 bitbox.py octal_to_binary 0` → `0`
- `python3 bitbox.py octal_to_binary 17` → `1111`
- Direct import smoke assertions for `12`, `0`, and `17` passed.
- `git diff --check` passed.
- `scan-tracked-secrets.py upstream/main` found no new secret-pattern occurrences; existing baseline matches were unchanged.
- Commit under test: `ceeaea42937faf2b986f807bbf2b1f3ac76806eb`.

The repository's contribution guide does not require a separate lint, typecheck, build, integration, or benchmark command for a stdlib-only single-tool addition.

Closes #379